### PR TITLE
Transliterator support

### DIFF
--- a/String.php
+++ b/String.php
@@ -462,6 +462,45 @@ class String implements \ArrayAccess, \Countable, \IteratorAggregate {
     }
 
     /**
+     * Transliterate the string into another.
+     * See self::getTransliterator for more information.
+     *
+     * @access  public
+     * @param   string  $identifier    Identifier.
+     * @param   int     $start         Start.
+     * @param   int     $end           End.
+     * @return  \Hoa\String
+     * @throw   \Hoa\String\Exception
+     */
+    public function transliterate ( $identifier, $start = 0, $end = null ) {
+
+        if(null === $transliterator = static::getTransliterator($identifier))
+            throw new Exception(
+                '%s needs the class Transliterator to work propertly.',
+                2, __METHOD__);
+
+        $this->_string = $transliterator->transliterate($this->_string, $start, $end);
+
+        return $this;
+    }
+
+    /**
+     * Get transliterator.
+     * See http://userguide.icu-project.org/transforms/general for $identifier.
+     *
+     * @access  public
+     * @param   string  $identifier    Identifier.
+     * @return  \Transliterator
+     */
+    public static function getTransliterator ( $identifier ) {
+
+        if(false === class_exists('Transliterator', false))
+            return null;
+
+        return \Transliterator::create($identifier);
+    }
+
+    /**
      * Strip characters (default \s) of the current string.
      *
      * @access  public

--- a/String.php
+++ b/String.php
@@ -299,7 +299,7 @@ class String implements \ArrayAccess, \Countable, \IteratorAggregate {
      */
     public static function getCollator ( ) {
 
-        if(false === class_exists('Collator', false))
+        if(false === class_exists('Collator'))
             return null;
 
         if(null === static::$_collator)
@@ -496,7 +496,7 @@ class String implements \ArrayAccess, \Countable, \IteratorAggregate {
             return $this;
         }
 
-        if(false === class_exists('Normalizer', false)) {
+        if(false === class_exists('Normalizer')) {
 
             if(false === $try)
                 throw new Exception(
@@ -550,7 +550,7 @@ class String implements \ArrayAccess, \Countable, \IteratorAggregate {
      */
     public static function getTransliterator ( $identifier ) {
 
-        if(false === class_exists('Transliterator', false))
+        if(false === class_exists('Transliterator'))
             return null;
 
         return \Transliterator::create($identifier);

--- a/String.php
+++ b/String.php
@@ -478,9 +478,20 @@ class String implements \ArrayAccess, \Countable, \IteratorAggregate {
 
         $string = $this->_string;
 
-        if(null !== $transliterator = static::getTransliterator('Any-Latin; Latin-ASCII')) {
+        $transId = 'Any-Latin; ' .
+                   '[\p{S}] Name; ' .
+                   'Latin-ASCII';
 
-            $this->_string = $transliterator->transliterate($string);
+        if(null !== $transliterator = static::getTransliterator($transId)) {
+
+            $this->_string = preg_replace_callback(
+                '#\\\N\{([A-Z ]+)\}#u',
+                function ( Array $matches ) {
+
+                    return '(' . strtolower($matches[1]) . ')';
+                },
+                $transliterator->transliterate($string)
+            );
 
             return $this;
         }

--- a/Test/Unit/String.php
+++ b/Test/Unit/String.php
@@ -937,7 +937,10 @@ class String extends Test\Unit\Suite {
                     => 'ksa',
 
                     'أحبك 😀'
-                    => 'ahbk (grinning face)'
+                    => 'ahbk (grinning face)',
+
+                    '∀ i ∈ ℕ'
+                    => '(for all) i (element of) N'
                 ]
             )
             ->when(function ( ) use ( $strings ) {

--- a/Test/Unit/String.php
+++ b/Test/Unit/String.php
@@ -915,9 +915,6 @@ class String extends Test\Unit\Suite {
                     'أحبك'
                     => 'ahbk',
 
-                    'رابتخالا وه اذه'
-                    => 'rabtkhala wh adhh',
-
                     'キャンパス'
                     => 'kyanpasu',
 

--- a/Test/Unit/String.php
+++ b/Test/Unit/String.php
@@ -848,13 +848,13 @@ class String extends Test\Unit\Suite {
                     ->isTrue();
     }
 
-    public function case_to_ascii_no_normalizer ( ) {
+    public function case_to_ascii_no_transliterator_no_normalizer ( ) {
 
         $this
             ->given(
                 $this->function->class_exists = function ( $name ) {
 
-                    return 'Normalizer' !== $name;
+                    return false === in_array($name, ['Transliterator', 'Normalizer']);
                 },
                 $string = new LUT('Un été brûlant sur la côte')
             )
@@ -865,13 +865,13 @@ class String extends Test\Unit\Suite {
                 ->isInstanceOf('Hoa\String\Exception');
     }
 
-    public function case_to_ascii_no_normalizer_try ( ) {
+    public function case_to_ascii_no_transliterator_no_normalizer_try ( ) {
 
         $this
             ->given(
                 $this->function->class_exists = function ( $name ) {
 
-                    return 'Normalizer' !== $name;
+                    return false === in_array($name, ['Transliterator', 'Normalizer']);
                 },
                 $string = new LUT('Un été brûlant sur la côte')
             )
@@ -883,16 +883,72 @@ class String extends Test\Unit\Suite {
                     ->isEqualTo('Un ete brulant sur la cote');
     }
 
-    public function case_to_ascii ( ) {
+    public function case_to_ascii_no_transliterator ( ) {
 
         $this
-            ->given($string = new LUT('Un été brûlant sur la côte'))
+            ->given(
+                $this->function->class_exists = function ( $name ) {
+
+                    return 'Transliterator' !== $name;
+                },
+                $string = new LUT('Un été brûlant sur la côte')
+            )
             ->when($result = $string->toAscii())
             ->then
                 ->object($result)
                     ->isIdenticalTo($string)
                 ->string((string) $result)
                     ->isEqualTo('Un ete brulant sur la cote');
+    }
+
+    public function case_to_ascii ( ) {
+
+        $this
+            ->given(
+                $strings = [
+                    'Un été brûlant sur la côte'
+                    => 'Un ete brulant sur la cote',
+
+                    'Αυτή είναι μια δοκιμή'
+                    => 'Aute einai mia dokime',
+
+                    'أحبك'
+                    => 'ahbk',
+
+                    'رابتخالا وه اذه'
+                    => 'rabtkhala wh adhh',
+
+                    'キャンパス'
+                    => 'kyanpasu',
+
+                    'биологическом'
+                    => 'biologiceskom',
+
+                    '정, 병호'
+                    => 'jeong, byeongho',
+
+                    'ますだ, よしひこ'
+                    => 'masuda, yoshihiko',
+
+                    'मोनिच'
+                    => 'monica',
+
+                    'क्ष'
+                    => 'ksa'
+                ]
+            )
+            ->when(function ( ) use ( $strings ) {
+
+                foreach($strings as $original => $asciied)
+                    $this
+                        ->given($string = new LUT($original))
+                        ->when($result = $string->toAscii())
+                        ->then
+                            ->object($result)
+                                ->isIdenticalTo($string)
+                            ->string((string) $result)
+                                ->isEqualTo($asciied);
+            });
     }
 
     public function case_copy ( ) {

--- a/Test/Unit/String.php
+++ b/Test/Unit/String.php
@@ -934,7 +934,10 @@ class String extends Test\Unit\Suite {
                     => 'monica',
 
                     'क्ष'
-                    => 'ksa'
+                    => 'ksa',
+
+                    'أحبك 😀'
+                    => 'ahbk (grinning face)'
                 ]
             )
             ->when(function ( ) use ( $strings ) {


### PR DESCRIPTION
1. Add transliterator.
2. `toAscii` then uses transliterator instead of normalizer when available.
3. Pure awesomeness.

See the tests:

Original | *Asciied*
---- | ----
Un été brûlant sur la côte | Un ete brulant sur la cote
Αυτή είναι μια δοκιμή | Aute einai mia dokime
أحبك | ahbk
キャンパス | kyanpasu
биологическом | biologiceskom
मोनिच | monica
أحبك 😀 | ahbk (grinning face)
∀ i ∈ ℕ | (for all) i (element of) N

Symbols support are just awesome I think :-p.

Asking a review from @osaris and @jubianchi, and the thought of @shine-neko!