### PR TITLE
`toCode` supports invalid UTF-8 character

### DIFF
--- a/String.php
+++ b/String.php
@@ -948,8 +948,9 @@ class String implements \ArrayAccess, \Countable, \IteratorAggregate {
      */
     public static function toCode ( $char ) {
 
-        $char = (string) $char;
-        $code = ord($char[0]);
+        $char  = (string) $char;
+        $code  = ord($char[0]);
+        $bytes = 1;
 
         if(!($code & 0x80)) // 0xxxxxxx
             return $code;

--- a/Test/Unit/Issue.php
+++ b/Test/Unit/Issue.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Ivan Enderlin. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\String\Test\Unit;
+
+use Hoa\Test;
+use Hoa\String as LUT;
+
+/**
+ * Class \Hoa\String\Test\Unit\Issue.
+ *
+ * Test suite of detected issues.
+ *
+ * @author     Ivan Enderlin <ivan.enderlin@hoa-project.net>
+ * @copyright  Copyright © 2007-2015 Ivan Enderlin.
+ * @license    New BSD License
+ */
+
+class Issue extends Test\Unit\Suite {
+
+    public function case_github_26 ( ) {
+
+        $this
+            ->when($result = LUT::toCode(chr(160)))
+            ->then
+                ->integer($result)
+                    ->isEqualTo(0xa0);
+    }
+}


### PR DESCRIPTION
In case where the `$char` given to `toCode` is not a valid UTF-8 character, a variable was missing. We fix this problem to mimic a valid UTF-8 character.

Fix https://github.com/hoaproject/String/issues/26. Thanks @mdarse for
the report!